### PR TITLE
fix: support Windows by switching signal handler API

### DIFF
--- a/tileget/__main__.py
+++ b/tileget/__main__.py
@@ -4,6 +4,7 @@ import os
 import random
 import signal
 import sqlite3
+import sys
 import time
 
 import httpx
@@ -237,17 +238,18 @@ async def run():
     params = parse_arg()
     start_time = time.monotonic()
 
-    # SIGINTハンドラを設定
-    loop = asyncio.get_running_loop()
-
-    def handle_sigint():
+    def handle_sigint(*_args):
         global shutdown_requested
         if not shutdown_requested:
             shutdown_requested = True
             print("\nShutdown requested. Waiting for running tasks to complete...")
 
-    loop.add_signal_handler(signal.SIGINT, handle_sigint)
-    loop.add_signal_handler(signal.SIGTERM, handle_sigint)
+    if sys.platform == "win32":
+        signal.signal(signal.SIGINT, handle_sigint)
+    else:
+        loop = asyncio.get_running_loop()
+        loop.add_signal_handler(signal.SIGINT, handle_sigint)
+        loop.add_signal_handler(signal.SIGTERM, handle_sigint)
 
     rate_limiter = RateLimiter(params.rps)
 


### PR DESCRIPTION
## Summary
- `loop.add_signal_handler` は Windows の asyncio で `NotImplementedError` を投げるため、現状の tileget は Windows で起動直後に落ちる
- `sys.platform == "win32"` のときは `signal.signal(signal.SIGINT, ...)` を使用し、Unix 系では従来どおり `loop.add_signal_handler` で SIGINT / SIGTERM を登録
- Windows には SIGTERM のシグナル配送機構が無いため SIGINT のみ対応

## Test plan
- [x] macOS で import / 起動できることを確認
- [ ] Windows で起動できること、Ctrl+C でグレースフルシャットダウンできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)